### PR TITLE
Added automatically select for bank account

### DIFF
--- a/app/views/transactions/_form.html.slim
+++ b/app/views/transactions/_form.html.slim
@@ -40,11 +40,12 @@
   - if transaction.transfer? && (params[:action] == 'edit' || params[:action] == 'update')
     = f.input :bank_account, disabled: true
   - elsif @invoice.present? || f.object.invoice_id
+    - selected_bank_account_id = @invoice&.bank_account_id || f.object.bank_account_id
     = f.association :bank_account, as: :grouped_select,
       collection: current_organization.bank_accounts.by_currency(@invoice.present? ? @invoice.currency \
       : current_organization.invoices.find_by(id: f.object.invoice_id).try(:currency)).visible.positioned.grouped_by_currency(current_organization.default_currency),
       prompt: 'Bank account', group_method: :last, label: transaction.transfer? ? 'To' : 'Bank account',
-      selected: f.object.bank_account_id
+      selected: selected_bank_account_id
   - elsif f.object.bank_account.nil? || f.object.bank_account.visible?
     = f.association :bank_account, as: :grouped_select,
       collection: current_organization.bank_accounts.visible.positioned.grouped_by_currency(current_organization.default_currency),


### PR DESCRIPTION
Now the bank account field will be pre-filled in the Transaction, but the option to change the user's selection will still be available.