### PR TITLE
Updated conditions for classifying invoices as overdue

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -67,7 +67,9 @@ class Invoice < ApplicationRecord
   end
 
   def overdue?
-    Date.current - ends_at.to_date > OVERDUE_DAYS
+    return false if self.sent_at.nil?
+
+    Date.current - sent_at.to_date > OVERDUE_DAYS
   end
 
   def pdf_filename

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -67,7 +67,7 @@ class Invoice < ApplicationRecord
   end
 
   def overdue?
-    return false if self.sent_at.nil?
+    return false if sent_at.nil?
 
     Date.current - sent_at.to_date > OVERDUE_DAYS
   end


### PR DESCRIPTION
An invoice is considered overdue if more than 14 days have passed since it was sent.